### PR TITLE
feat: add support for PEP 621

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "semantic-release-poetry-plugin",
+    "name": "@covage/semantic-release-poetry-plugin",
     "version": "0.0.0-development",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "semantic-release-poetry-plugin",
+            "name": "@covage/semantic-release-poetry-plugin",
             "version": "0.0.0-development",
             "license": "MIT",
             "dependencies": {

--- a/src/poetry_version_replace.js
+++ b/src/poetry_version_replace.js
@@ -1,24 +1,41 @@
 function replaceTomlToolPoetryVersion(content, newVersion) {
     let newContent = content;
 
-    // find the first occurence of version after tool.poetry
+    // Try tool.poetry section first
     const toolPoetrySectionStart = content.indexOf("[tool.poetry]");
-    if (toolPoetrySectionStart === -1) {
-        throw new Error("Could not find [tool.poetry] section in pyproject.toml");
+    if (toolPoetrySectionStart !== -1) {
+        const toolPoetryVersionLineStart = toolPoetrySectionStart + content.substring(toolPoetrySectionStart).indexOf("version = ");
+        if (toolPoetryVersionLineStart !== -1) {
+            const toolPoetryVersionValueStart = toolPoetryVersionLineStart + content.substring(toolPoetryVersionLineStart).indexOf('"');
+            const lineEndRelativePos = content.substring(toolPoetryVersionLineStart).indexOf('\n');
+            let versionLineEnd = toolPoetryVersionLineStart + lineEndRelativePos;
+            if (lineEndRelativePos === -1) {
+                versionLineEnd = content.length;
+            }
+            return content.substring(0, toolPoetryVersionValueStart) + '"' + newVersion + '"' + content.substring(versionLineEnd);
+        }
     }
-    const toolPoetryVersionLineStart = toolPoetrySectionStart + content.substring(toolPoetrySectionStart).indexOf("version = ");
-    const toolPoetryVersionValueStart = toolPoetryVersionLineStart + content.substring(toolPoetryVersionLineStart).indexOf('"');
-    if (toolPoetryVersionLineStart === -1) {
-        throw new Error("Could not find tool.poetry.version key in pyproject.toml");
-    }
-    const lineEndRelativePos = content.substring(toolPoetryVersionLineStart).indexOf('\n');
-    let versionLineEnd = toolPoetryVersionLineStart + lineEndRelativePos;
-    if (lineEndRelativePos === -1) {
-        versionLineEnd = content.length;
-    }
-    newContent = content.substring(0, toolPoetryVersionValueStart) + '"' + newVersion + '"' + content.substring(versionLineEnd);
 
-    return newContent;
+    // If not found, try project section (uv)
+    const projectSectionStart = content.indexOf("[project]");
+    if (projectSectionStart !== -1) {
+        const projectVersionLineStart = projectSectionStart + content.substring(projectSectionStart).indexOf("version = ");
+        if (projectVersionLineStart !== -1) {
+            const projectVersionValueStart = projectVersionLineStart + content.substring(projectVersionLineStart).indexOf('"');
+            const lineEndRelativePos = content.substring(projectVersionLineStart).indexOf('\n');
+            let versionLineEnd = projectVersionLineStart + lineEndRelativePos;
+            if (lineEndRelativePos === -1) {
+                versionLineEnd = content.length;
+            }
+            return content.substring(0, projectVersionValueStart) + '"' + newVersion + '"' + content.substring(versionLineEnd);
+        }
+    }
+
+    // If neither section found or no version in either section
+    if (toolPoetrySectionStart === -1 && projectSectionStart === -1) {
+        throw new Error("Could not find [tool.poetry] or [project] section in pyproject.toml");
+    }
+    throw new Error("Could not find version key in pyproject.toml");
 }
 
 module.exports = {

--- a/test/poetry_version_replace.test.js
+++ b/test/poetry_version_replace.test.js
@@ -60,7 +60,7 @@ describe('poetry version replace', () => {
 
         expect(
             () => poetryReplace.replaceTomlToolPoetryVersion(content, "43.2.3")
-        ).toThrow(Error("Could not find [tool.poetry] section in pyproject.toml"))
+        ).toThrow(Error("Could not find [tool.poetry] or [project] section in pyproject.toml"))
     });
 
     test('replace with absent tool.poetry.version field', async () => {
@@ -72,7 +72,22 @@ describe('poetry version replace', () => {
 
         expect(
             () => poetryReplace.replaceTomlToolPoetryVersion(content, "43.2.3")
-        ).toThrow(Error("Could not find tool.poetry.version key in pyproject.toml"))
+        ).toThrow(Error("Could not find version key in pyproject.toml"))
+    });
+
+    test('replace in full TOML by uv', async () => {
+        const content = [
+            `[project]`,
+            `name = "my_lib"`,
+            `version = "42.0.0"`,
+            `description = "Lib to do thing"`,
+            `authors = ["John Doe <john@example.org"]`,
+            `keywords = []`,
+            `license = "MIT"`,
+            `readme = "README.md"`,
+        ].join('\n')
+        const res = poetryReplace.replaceTomlToolPoetryVersion(content, "43.9.9")
+        expect(res.split('\n')[2]).toBe(`version = "43.9.9"`)
     });
 }); 
 

--- a/test/poetry_version_replace.test.js
+++ b/test/poetry_version_replace.test.js
@@ -1,7 +1,7 @@
 const poetryReplace = require('../src/poetry_version_replace');
 
 describe('poetry version replace', () => {
-    test('replace simple TOML 1', async () => {
+    test('replace simple Poetry TOML, version line is the last', async () => {
         const content = [
             `[tool.poetry]`,
             `version = "0.1.0"`,
@@ -11,7 +11,7 @@ describe('poetry version replace', () => {
         expect(res.split('\n').length).toBe(2)
     });
 
-    test('replace simple TOML 2', async () => {
+    test('replace simple Poetry TOML, version line is in the middle', async () => {
         const content = [
             `[tool.poetry]`,
             `name = "my_lib"`,
@@ -22,7 +22,7 @@ describe('poetry version replace', () => {
         expect(res.split('\n')[2]).toBe(`version = "43.2.3"`)
     });
 
-    test('replace in full TOML', async () => {
+    test('replace in full Poetry TOML', async () => {
         const content = [
             `[tool.poetry]`,
             `name = "my_lib"`,
@@ -52,7 +52,7 @@ describe('poetry version replace', () => {
         expect(res.split('\n')[2]).toBe(`version = "43.9.9"`)
     });
 
-    test('replace with absent tool.poetry section', async () => {
+    test('replace with no tool.poetry section', async () => {
         const content = [
             `name = "my_lib"`,
             `description = "Lib to do thing"`
@@ -75,19 +75,19 @@ describe('poetry version replace', () => {
         ).toThrow(Error("Could not find version key in pyproject.toml"))
     });
 
-    test('replace in full TOML by uv', async () => {
+    test('replace in full UV TOML', async () => {
         const content = [
             `[project]`,
             `name = "my_lib"`,
-            `version = "42.0.0"`,
+            `version = "42.1.1"`,
             `description = "Lib to do thing"`,
             `authors = ["John Doe <john@example.org"]`,
             `keywords = []`,
             `license = "MIT"`,
             `readme = "README.md"`,
         ].join('\n')
-        const res = poetryReplace.replaceTomlToolPoetryVersion(content, "43.9.9")
-        expect(res.split('\n')[2]).toBe(`version = "43.9.9"`)
+        const res = poetryReplace.replaceTomlToolPoetryVersion(content, "43.0.0")
+        expect(res.split('\n')[2]).toBe(`version = "43.0.0"`)
     });
 }); 
 


### PR DESCRIPTION
This add support for the [PEP 621 version standard](https://peps.python.org/pep-0621/#version) used by [UV](https://docs.astral.sh/uv/).
